### PR TITLE
feat(info): enhance info command with server version check

### DIFF
--- a/cmd/__snapshots__/info_test.snap
+++ b/cmd/__snapshots__/info_test.snap
@@ -1,0 +1,58 @@
+
+[TestInfoCmd/Happy_path_-_all_compatible - 1]
+aerospace-marks info
+Aerospace Marks CLI - Configuration
+
+[Socket]
+Path: /tmp/foo.sock
+Version: aerospace-ipc v0.1.0
+Status: Compatible.
+
+[Database]
+Name: storage.db
+Path: /Users/cristianoliveira/.local/state/aerospace-marks
+
+[Logging]
+Path: /tmp/aerospace-marks.log
+Level: DISABLED
+
+Configure with ENV variables:
+AEROSPACESOCK - Path to the socket file.
+AEROSPACE_MARKS_DB_PATH - Path to database directory.
+AEROSPACE_MARKS_LOGS_LEVEL - Log level [debug|info|warn|error] (default: disabled)
+AEROSPACE_MARKS_LOGS_PATH - Path to the logs file.
+
+---
+
+[TestInfoCmd/Happy_path_-_non_compatible - 1]
+aerospace-marks info
+Aerospace Marks CLI - Configuration
+
+[Socket]
+Path: /tmp/foo.sock
+Version: aerospace-ipc v3.1.0
+Status: Incompatible. Reason: incompatible version because reasons
+
+[Database]
+Name: storage.db
+Path: /Users/cristianoliveira/.local/state/aerospace-marks
+
+[Logging]
+Path: /tmp/aerospace-marks.log
+Level: DISABLED
+
+Configure with ENV variables:
+AEROSPACESOCK - Path to the socket file.
+AEROSPACE_MARKS_DB_PATH - Path to database directory.
+AEROSPACE_MARKS_LOGS_LEVEL - Log level [debug|info|warn|error] (default: disabled)
+AEROSPACE_MARKS_LOGS_PATH - Path to the logs file.
+
+---
+
+[TestInfoCmd/Failure_-_to_retrieve_socket_path - 1]
+aerospace-marks info
+Output
+
+Error
+failed to get socket path: missing socket path
+---

--- a/cmd/__snapshots__/info_test.snap
+++ b/cmd/__snapshots__/info_test.snap
@@ -9,8 +9,8 @@ Version: aerospace-ipc v0.1.0
 Status: Compatible.
 
 [Database]
-Name: storage.db
-Path: /Users/cristianoliveira/.local/state/aerospace-marks
+Name: foo.db
+Path: /tmp/database/
 
 [Logging]
 Path: /tmp/aerospace-marks.log
@@ -34,8 +34,8 @@ Version: aerospace-ipc v3.1.0
 Status: Incompatible. Reason: incompatible version because reasons
 
 [Database]
-Name: storage.db
-Path: /Users/cristianoliveira/.local/state/aerospace-marks
+Name: foo.db
+Path: /tmp/database/
 
 [Logging]
 Path: /tmp/aerospace-marks.log

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -34,10 +34,23 @@ It also displays help information about environment variables available.
 				return fmt.Errorf("failed to get socket path: %w", err)
 			}
 
-			cmd.Println(fmt.Sprintf(`Aerospace Marks CLI - Configuration
+			var validationInfo string
+			if err = client.CheckServerVersion(); err != nil {
+				validationInfo = "Incompatible. Reason: " + err.Error()
+			} else {
+				validationInfo = "Compatible."
+			}
+			serverVersion, err := client.GetServerVersion()
+			if err != nil {
+				return fmt.Errorf("failed to get server version: %w", err)
+			}
+
+			fmt.Printf(`Aerospace Marks CLI - Configuration
 
 [Socket]
 Path: %s
+Version: %s
+Status: %s
 
 [Database]
 Name: %s
@@ -52,17 +65,25 @@ Configure with ENV variables:
 %s - Path to database directory.
 %s - Log level [debug|info|warn|error] (default: disabled)
 %s - Path to the logs file.
-			`,
+`,
 				socketPath,
+				serverVersion,
+				validationInfo,
+
+				// Database configuration
 				dbConfig.DbName,
 				dbConfig.DbPath,
+
+				// logging configuration
 				logConfig.Path,
 				logConfig.Level,
+
+				// Environment variables
 				constants.EnvAeroSpaceSock,
 				constants.EnvAeroSpaceMarksDbPath,
 				constants.EnvAeroSpaceMarksLogsLevel,
 				constants.EnvAeroSpaceMarksLogsPath,
-			))
+			)
 
 			return nil
 		},

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -15,6 +15,7 @@ import (
 
 // configCmd represents the config command
 func InfoCmd(
+	storageClient storage.MarkStorage,
 	aerospaceClient aerospace.AerosSpaceMarkWindows,
 ) *cobra.Command {
 	return &cobra.Command{
@@ -27,7 +28,7 @@ It also displays help information about environment variables available.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logConfig := logger.GetDefaultLogger().GetConfig()
-			dbConfig := storage.GetDatabaseConfig()
+			dbConfig := storageClient.Client().GetStorageConfig()
 			client := aerospaceClient.Client().Connection()
 			socketPath, err := client.GetSocketPath()
 			if err != nil {

--- a/cmd/info_test.go
+++ b/cmd/info_test.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/cristianoliveira/aerospace-marks/internal/mocks"
+	"github.com/cristianoliveira/aerospace-marks/internal/testutils"
+	"github.com/gkampitakis/go-snaps/snaps"
+	"go.uber.org/mock/gomock"
+)
+
+func TestInfoCmd(t *testing.T) {
+	t.Run("Happy path - all compatible", func(tt *testing.T) {
+		ctrl := gomock.NewController(tt)
+		defer ctrl.Finish()
+
+		aerospaceConnection, aerospaceClient := mocks.MockAerospaceConnection(ctrl)
+
+		gomock.InOrder(
+			aerospaceConnection.
+				EXPECT().
+				GetSocketPath().
+				Return("/tmp/foo.sock", nil).
+				Times(1),
+
+			aerospaceConnection.
+				EXPECT().
+				CheckServerVersion().
+				Return(nil).
+				Times(1),
+
+			aerospaceConnection.
+				EXPECT().
+				GetServerVersion().
+				Return("aerospace-ipc v0.1.0", nil).
+				Times(1),
+		)
+
+		cmd := InfoCmd(aerospaceClient)
+		out, err := testutils.CmdExecute(cmd)
+		if err != nil {
+			tt.Fatal(err)
+		}
+
+		cmdExecuted := fmt.Sprintf("aerospace-marks %s", cmd.Use)
+		snaps.MatchSnapshot(tt, cmdExecuted, out)
+	})
+
+	t.Run("Happy path - non compatible", func(tt *testing.T) {
+		ctrl := gomock.NewController(tt)
+		defer ctrl.Finish()
+
+		aerospaceConnection, aerospaceClient := mocks.MockAerospaceConnection(ctrl)
+
+		gomock.InOrder(
+			aerospaceConnection.
+				EXPECT().
+				GetSocketPath().
+				Return("/tmp/foo.sock", nil).
+				Times(1),
+
+			aerospaceConnection.
+				EXPECT().
+				CheckServerVersion().
+				Return(errors.New("incompatible version because reasons")).
+				Times(1),
+
+			aerospaceConnection.
+				EXPECT().
+				GetServerVersion().
+				Return("aerospace-ipc v3.1.0", nil).
+				Times(1),
+		)
+
+		cmd := InfoCmd(aerospaceClient)
+		out, err := testutils.CmdExecute(cmd)
+		if err != nil {
+			tt.Fatal(err)
+		}
+
+		cmdExecuted := fmt.Sprintf("aerospace-marks %s", cmd.Use)
+		snaps.MatchSnapshot(tt, cmdExecuted, out)
+	})
+
+	t.Run("Failure - to retrieve socket path", func(tt *testing.T) {
+		ctrl := gomock.NewController(tt)
+		defer ctrl.Finish()
+
+		aerospaceConnection, aerospaceClient := mocks.MockAerospaceConnection(ctrl)
+
+		gomock.InOrder(
+			aerospaceConnection.
+				EXPECT().
+				GetSocketPath().
+				Return("", errors.New("missing socket path")).
+				Times(1),
+		)
+
+		cmd := InfoCmd(aerospaceClient)
+		out, err := testutils.CmdExecute(cmd)
+		if err == nil {
+			tt.Fatal(err)
+		}
+
+		cmdExecuted := fmt.Sprintf("aerospace-marks %s", cmd.Use)
+		snaps.MatchSnapshot(tt, cmdExecuted, "Output", out, "Error", err.Error())
+	})
+}

--- a/cmd/info_test.go
+++ b/cmd/info_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cristianoliveira/aerospace-marks/internal/mocks"
+	"github.com/cristianoliveira/aerospace-marks/internal/storage"
 	"github.com/cristianoliveira/aerospace-marks/internal/testutils"
 	"github.com/gkampitakis/go-snaps/snaps"
 	"go.uber.org/mock/gomock"
@@ -17,6 +18,16 @@ func TestInfoCmd(t *testing.T) {
 		defer ctrl.Finish()
 
 		aerospaceConnection, aerospaceClient := mocks.MockAerospaceConnection(ctrl)
+		dbClient, storageClient := mocks.MockStorageDbClient(ctrl)
+
+		dbClient.
+			EXPECT().
+			GetStorageConfig().
+			Return(storage.StorageConfig{
+				DbPath: "/tmp/database/",
+				DbName: "foo.db",
+			}).
+			Times(1)
 
 		gomock.InOrder(
 			aerospaceConnection.
@@ -38,7 +49,10 @@ func TestInfoCmd(t *testing.T) {
 				Times(1),
 		)
 
-		cmd := InfoCmd(aerospaceClient)
+		cmd := InfoCmd(
+			storageClient,
+			aerospaceClient,
+		)
 		out, err := testutils.CmdExecute(cmd)
 		if err != nil {
 			tt.Fatal(err)
@@ -53,6 +67,16 @@ func TestInfoCmd(t *testing.T) {
 		defer ctrl.Finish()
 
 		aerospaceConnection, aerospaceClient := mocks.MockAerospaceConnection(ctrl)
+		dbClient, storageClient := mocks.MockStorageDbClient(ctrl)
+
+		dbClient.
+			EXPECT().
+			GetStorageConfig().
+			Return(storage.StorageConfig{
+				DbPath: "/tmp/database/",
+				DbName: "foo.db",
+			}).
+			Times(1)
 
 		gomock.InOrder(
 			aerospaceConnection.
@@ -74,7 +98,10 @@ func TestInfoCmd(t *testing.T) {
 				Times(1),
 		)
 
-		cmd := InfoCmd(aerospaceClient)
+		cmd := InfoCmd(
+			storageClient,
+			aerospaceClient,
+		)
 		out, err := testutils.CmdExecute(cmd)
 		if err != nil {
 			tt.Fatal(err)
@@ -89,6 +116,16 @@ func TestInfoCmd(t *testing.T) {
 		defer ctrl.Finish()
 
 		aerospaceConnection, aerospaceClient := mocks.MockAerospaceConnection(ctrl)
+		dbClient, storageClient := mocks.MockStorageDbClient(ctrl)
+
+		dbClient.
+			EXPECT().
+			GetStorageConfig().
+			Return(storage.StorageConfig{
+				DbPath: "/tmp/database/",
+				DbName: "foo.db",
+			}).
+			Times(1)
 
 		gomock.InOrder(
 			aerospaceConnection.
@@ -98,7 +135,10 @@ func TestInfoCmd(t *testing.T) {
 				Times(1),
 		)
 
-		cmd := InfoCmd(aerospaceClient)
+		cmd := InfoCmd(
+			storageClient,
+			aerospaceClient,
+		)
 		out, err := testutils.CmdExecute(cmd)
 		if err == nil {
 			tt.Fatal(err)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,7 +30,7 @@ This CLI is heavily inspired by the marks feature of i3 and sway window managers
 	newRootCmd.AddCommand(UnmarkCmd(storage))
 	newRootCmd.AddCommand(FocusCmd(storage, aerospaceClient))
 	newRootCmd.AddCommand(ListCmd(storage, aerospaceClient))
-	newRootCmd.AddCommand(InfoCmd(aerospaceClient))
+	newRootCmd.AddCommand(InfoCmd(storage, aerospaceClient))
 	newRootCmd.AddCommand(SummonCmd(storage, aerospaceClient))
 	newRootCmd.AddCommand(GetCmd(storage, aerospaceClient))
 

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -22,7 +22,7 @@ func MockStorageDbClient(ctrl *gomock.Controller) (*storage_mock.MockStorageDbCl
 
 	newStorage, err := storage.NewMarkClient(storageDbClient)
 	if err != nil {
-		panic(err)
+		ctrl.T.Errorf("failed to create new storage client: %v", err)
 	}
 
 	return storageDbClient, newStorage

--- a/internal/mocks/storage/client_mock.go
+++ b/internal/mocks/storage/client_mock.go
@@ -128,6 +128,20 @@ func (mr *MockStorageDbClientMockRecorder) Execute(query any, args ...any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockStorageDbClient)(nil).Execute), varargs...)
 }
 
+// GetStorageConfig mocks base method.
+func (m *MockStorageDbClient) GetStorageConfig() storage.StorageConfig {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStorageConfig")
+	ret0, _ := ret[0].(storage.StorageConfig)
+	return ret0
+}
+
+// GetStorageConfig indicates an expected call of GetStorageConfig.
+func (mr *MockStorageDbClientMockRecorder) GetStorageConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageConfig", reflect.TypeOf((*MockStorageDbClient)(nil).GetStorageConfig))
+}
+
 // QueryAll mocks base method.
 func (m *MockStorageDbClient) QueryAll(query string, args ...any) ([]storage.Mark, error) {
 	m.ctrl.T.Helper()

--- a/internal/storage/marks.go
+++ b/internal/storage/marks.go
@@ -30,6 +30,8 @@ type MarkStorage interface {
 	DeleteAllMarks() (int64, error)
 	// Close closes the database connection
 	Close() error
+	// Client returns the storage client
+	Client() StorageDbClient
 }
 
 type MarkStorageClient struct {
@@ -136,6 +138,11 @@ func (c *MarkStorageClient) ReplaceAllMarks(id string, mark string) (int64, erro
 
 func (c *MarkStorageClient) Close() error {
 	return c.storage.Close()
+}
+
+// Client returns the storage client
+func (c *MarkStorageClient) Client() StorageDbClient {
+	return c.storage
 }
 
 // ToggleMark toggles a mark for a window

--- a/internal/storage/marks_test.go
+++ b/internal/storage/marks_test.go
@@ -39,6 +39,9 @@ func (m *MockMarkStorage) Close() error {
 	m.RecordArgs = append(m.RecordArgs, "close")
 	return nil
 }
+func (m *MockMarkStorage) GetStorageConfig() StorageConfig {
+	return StorageConfig{}
+}
 
 func TestMarksStorageClient(t *testing.T) {
 	logger.SetDefaultLogger(&logger.EmptyLogger{})


### PR DESCRIPTION
Summary:
Introduced server version compatibility check to the info command and added test cases for different scenarios.

Detailed Changes:
 - cmd/info.go:
   - Added server version compatibility check and validation information in the output.
   - Displayed server version and compatibility status with reasons for incompatibility.
 - cmd/info_test.go:
   - Created testing scenarios for socket path retrieval success and failure cases.
   - Added test cases for compatible and non-compatible server version scenarios.