### PR TITLE
chore(ci): update fetch-depth in GitHub Actions

### DIFF
--- a/.github/workflows/reset-nightly.yml
+++ b/.github/workflows/reset-nightly.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Make sure to clone with at least last and before last commits
+          fetch-depth: 2
 
       - name: reset nightly branch
         uses: nicksnell/action-reset-repo@master


### PR DESCRIPTION
Summary:
This commit updates the GitHub Actions workflow by modifying the checkout action to ensure the right commit depth is fetched.

Error:
```
'HEAD~': unknown revision or path
```