### PR TITLE
chore(deps): update module versions and hashes

### DIFF
--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -62,7 +62,7 @@ func TestGetCommand(t *testing.T) {
 					"--all",
 					"--json",
 					"--format",
-					"%{window-id} %{app-name} %{app-bundle-id} %{workspace}",
+					"%{window-id} %{window-title} %{app-name} %{app-bundle-id} %{workspace}",
 				}).
 			Return(
 				&aerospacecli.Response{
@@ -178,7 +178,7 @@ func TestGetCommand(t *testing.T) {
 					"--all",
 					"--json",
 					"--format",
-					"%{window-id} %{app-name} %{app-bundle-id} %{workspace}",
+					"%{window-id} %{window-title} %{app-name} %{app-bundle-id} %{workspace}",
 				}).
 			Return(
 				&aerospacecli.Response{

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -65,7 +65,7 @@ func TestListCommand(t *testing.T) {
 					"--all",
 					"--json",
 					"--format",
-					"%{window-id} %{app-name} %{app-bundle-id} %{workspace}",
+					"%{window-id} %{window-title} %{app-name} %{app-bundle-id} %{workspace}",
 				}).
 			Return(
 				&aerospacecli.Response{
@@ -140,7 +140,7 @@ func TestListCommand(t *testing.T) {
 					"--all",
 					"--json",
 					"--format",
-					"%{window-id} %{app-name} %{app-bundle-id} %{workspace}",
+					"%{window-id} %{window-title} %{app-name} %{app-bundle-id} %{workspace}",
 				}).
 			Return(
 				&aerospacecli.Response{
@@ -212,7 +212,7 @@ func TestListCommand(t *testing.T) {
 					"--all",
 					"--json",
 					"--format",
-					"%{window-id} %{app-name} %{app-bundle-id} %{workspace}",
+					"%{window-id} %{window-title} %{app-name} %{app-bundle-id} %{workspace}",
 				}).
 			Return(&aerospacecli.Response{
 				ServerVersion: "1.0",

--- a/cmd/mark_test.go
+++ b/cmd/mark_test.go
@@ -59,7 +59,7 @@ func TestMarkCommand(t *testing.T) {
 					"--focused",
 					"--json",
 					"--format",
-					"%{window-id} %{app-name} %{app-bundle-id} %{workspace}",
+					"%{window-id} %{window-title} %{app-name} %{app-bundle-id} %{workspace}",
 				}).
 			Return(
 				&aerospacecli.Response{
@@ -128,7 +128,7 @@ func TestMarkCommand(t *testing.T) {
 					"--all",
 					"--json",
 					"--format",
-					"%{window-id} %{app-name} %{app-bundle-id} %{workspace}",
+					"%{window-id} %{window-title} %{app-name} %{app-bundle-id} %{workspace}",
 				}).
 			Return(
 				&aerospacecli.Response{
@@ -182,8 +182,8 @@ func TestMarkCommand(t *testing.T) {
 				[]string{
 					"--focused",
 					"--json",
-					"--format",
-					"%{window-id} %{app-name} %{app-bundle-id} %{workspace}",
+					"--format", 
+					"%{window-id} %{window-title} %{app-name} %{app-bundle-id} %{workspace}",
 				}).
 			Return(
 				&aerospacecli.Response{
@@ -271,7 +271,7 @@ func TestMarkCommand(t *testing.T) {
 					"--focused",
 					"--json",
 					"--format",
-					"%{window-id} %{app-name} %{app-bundle-id} %{workspace}",
+					"%{window-id} %{window-title} %{app-name} %{app-bundle-id} %{workspace}",
 				}).
 			Return(
 				&aerospacecli.Response{
@@ -334,7 +334,7 @@ func TestMarkCommand(t *testing.T) {
 					"--focused",
 					"--json",
 					"--format",
-					"%{window-id} %{app-name} %{app-bundle-id} %{workspace}",
+					"%{window-id} %{window-title} %{app-name} %{app-bundle-id} %{workspace}",
 				}).
 			Return(
 				&aerospacecli.Response{

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.2
 toolchain go1.24.3
 
 require (
-	github.com/cristianoliveira/aerospace-ipc v0.2.0 // indirect
+	github.com/cristianoliveira/aerospace-ipc v0.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gkampitakis/ciinfo v0.3.1 // indirect
 	github.com/gkampitakis/go-diff v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/cristianoliveira/aerospace-ipc v0.1.2-0.20250608182735-f8d5f30434b7 h
 github.com/cristianoliveira/aerospace-ipc v0.1.2-0.20250608182735-f8d5f30434b7/go.mod h1:Dr928g0F980Y/Hu1t60RKOiWvQF02Lx5nLLM0SwPZ7M=
 github.com/cristianoliveira/aerospace-ipc v0.2.0 h1:DNifQfsdogX0CTS5wDgYcZmZWzctDFYxQmO9tMtxlW0=
 github.com/cristianoliveira/aerospace-ipc v0.2.0/go.mod h1:Dr928g0F980Y/Hu1t60RKOiWvQF02Lx5nLLM0SwPZ7M=
+github.com/cristianoliveira/aerospace-ipc v0.2.1 h1:3APvgZvcQiYO2W+ElxOD+guYYK4amRlR5WfD41SkkXU=
+github.com/cristianoliveira/aerospace-ipc v0.2.1/go.mod h1:Dr928g0F980Y/Hu1t60RKOiWvQF02Lx5nLLM0SwPZ7M=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gkampitakis/ciinfo v0.3.1 h1:lzjbemlGI4Q+XimPg64ss89x8Mf3xihJqy/0Mgagapo=

--- a/nix/package-source.nix
+++ b/nix/package-source.nix
@@ -9,7 +9,7 @@
     # sources that will be used for our derivation.
     src = ../.;
 
-    vendorHash = "sha256-0s4aCxaWRolYdLadouszxnrlT+9x+PpJiOaQ4pUPhAM=";
+    vendorHash = "sha256-9FNgpx4PtA9VCbeMdo+BQaED0MWGNmX8E0YjFNsSy04=";
 
     ldflags = [
       "-s" "-w"


### PR DESCRIPTION
Summary:
Updated version for `github.com/cristianoliveira/aerospace-ipc`

Detailed Changes:
 - go.mod:
   - Updated the version of `github.com/cristianoliveira/aerospace-ipc` from v0.2.0 to v0.2.1.
 - go.sum:
   - Added checksums for the new version of `github.com/cristianoliveira/aerospace-ipc` v0.2.1.
 - nix/package-source.nix:
   - Changed the `vendorHash` value to reflect updated dependencies.