### PR TITLE
feat: support retrieval by app-bundle-id for get cmd

### DIFF
--- a/cmd/__snapshots__/get_test.snap
+++ b/cmd/__snapshots__/get_test.snap
@@ -40,3 +40,17 @@ aerospace-marks get mark1 -a
 
 app1
 ---
+
+[TestGetCommand/shows_only_the_marked_windows_app-bundle-id - 1]
+[]storage.Mark{
+    {WindowID:"1", Mark:"mark1"},
+}
+[]aerospace.Window{
+    {WindowID:1, WindowTitle:"title1", AppName:"app1", AppBundleID:"bundle1", Workspace:""},
+    {WindowID:2, WindowTitle:"title2", AppName:"app2", AppBundleID:"bundle2", Workspace:""},
+    {WindowID:3, WindowTitle:"title3", AppName:"app3", AppBundleID:"bundle3", Workspace:""},
+}
+aerospace-marks get mark1 --app-bundle-id
+
+bundle1
+---

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -55,9 +55,6 @@ This command retrieves a window by its mark (identifier). Print in the following
 				return
 			}
 
-			getWinTitle, _ := cmd.Flags().GetBool("window-title")
-			getWinApp, _ := cmd.Flags().GetBool("app-name")
-
 			window, err := aerospaceClient.GetWindowByID(windowID)
 			logger.LogDebug(
 				"Get window by ID",
@@ -75,13 +72,21 @@ This command retrieves a window by its mark (identifier). Print in the following
 				return
 			}
 
+			getWinTitle, _ := cmd.Flags().GetBool("window-title")
 			if getWinTitle {
 				fmt.Print(window.WindowTitle)
 				return
 			}
 
+			getWinApp, _ := cmd.Flags().GetBool("app-name")
 			if getWinApp {
 				fmt.Print(window.AppName)
+				return
+			}
+
+			getWinAppBundleID, _ := cmd.Flags().GetBool("app-bundle-id")
+			if getWinAppBundleID {
+				fmt.Print(window.AppBundleID)
 				return
 			}
 
@@ -97,6 +102,7 @@ This command retrieves a window by its mark (identifier). Print in the following
 	getCmd.Flags().BoolP("window-id", "i", false, "Get only window [i]D")
 	getCmd.Flags().BoolP("window-title", "t", false, "Get only window [t]itle")
 	getCmd.Flags().BoolP("app-name", "a", false, "Get only window [a]pp name")
+	getCmd.Flags().BoolP("app-bundle-id", "b", false, "Get only window app [b]undle ID")
 
 	return getCmd
 }


### PR DESCRIPTION
Summary:
Added functionality to retrieve window information by application bundle ID.

Detailed Changes:
 - cmd/get.go:
   - Introduced a new flag `--app-bundle-id` to fetch windows by their application bundle ID.
   - Reorganized flag retrievals to include the new feature.
 - cmd/get_test.go:
   - Added a test case "shows only the marked windows app-bundle-id" to validate the new feature.
 - cmd/__snapshots__/get_test.snap:
   - Updated snapshot to reflect the addition of the app-bundle-id functionality.