### PR TITLE
refactor(aerospace): switch WindowID to integer type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ bin/
 result
 _tmp/
 
-./aerospace-marks
+aerospace-marks

--- a/cmd/__snapshots__/get_test.snap
+++ b/cmd/__snapshots__/get_test.snap
@@ -1,7 +1,7 @@
 
 [TestGetCommand/shows_only_the_marked_windows - 1]
-[]struct { WindowID string "json:\"window_id\""; Mark string "json:\"mark\"" }{
-    {WindowID:"1", Mark:"mark1"},
+[]struct { WindowID int "json:\"window_id\""; Mark string "json:\"mark\"" }{
+    {WindowID:1, Mark:"mark1"},
 }
 []aerospace.Window{
     {WindowID:1, WindowTitle:"title1", AppName:"app1", AppBundleID:"", Workspace:""},
@@ -14,8 +14,8 @@ aerospace-marks get mark1
 ---
 
 [TestGetCommand/shows_only_the_marked_windows_id - 1]
-[]struct { WindowID string "json:\"window_id\""; Mark string "json:\"mark\"" }{
-    {WindowID:"1", Mark:"mark1"},
+[]struct { WindowID int "json:\"window_id\""; Mark string "json:\"mark\"" }{
+    {WindowID:1, Mark:"mark1"},
 }
 []aerospace.Window{
     {WindowID:1, WindowTitle:"title1", AppName:"app1", AppBundleID:"", Workspace:""},
@@ -28,8 +28,8 @@ aerospace-marks get mark1 --window-id
 ---
 
 [TestGetCommand/shows_only_the_marked_windows_app-name - 1]
-[]struct { WindowID string "json:\"window_id\""; Mark string "json:\"mark\"" }{
-    {WindowID:"1", Mark:"mark1"},
+[]struct { WindowID int "json:\"window_id\""; Mark string "json:\"mark\"" }{
+    {WindowID:1, Mark:"mark1"},
 }
 []aerospace.Window{
     {WindowID:1, WindowTitle:"title1", AppName:"app1", AppBundleID:"", Workspace:""},
@@ -42,8 +42,8 @@ app1
 ---
 
 [TestGetCommand/shows_only_the_marked_windows_app-bundle-id - 1]
-[]struct { WindowID string "json:\"window_id\""; Mark string "json:\"mark\"" }{
-    {WindowID:"1", Mark:"mark1"},
+[]struct { WindowID int "json:\"window_id\""; Mark string "json:\"mark\"" }{
+    {WindowID:1, Mark:"mark1"},
 }
 []aerospace.Window{
     {WindowID:1, WindowTitle:"title1", AppName:"app1", AppBundleID:"bundle1", Workspace:""},

--- a/cmd/__snapshots__/list_test.snap
+++ b/cmd/__snapshots__/list_test.snap
@@ -38,12 +38,12 @@
   }
 ]
 
-[]struct { WindowID string "json:\"window_id\""; Mark string "json:\"mark\"" }{
-    {WindowID:"1", Mark:"mark-1"},
-    {WindowID:"22", Mark:"mark-2"},
-    {WindowID:"3", Mark:"mark-3"},
-    {WindowID:"444", Mark:"mark-4"},
-    {WindowID:"5555", Mark:"mark-5"},
+[]struct { WindowID int "json:\"window_id\""; Mark string "json:\"mark\"" }{
+    {WindowID:1, Mark:"mark-1"},
+    {WindowID:22, Mark:"mark-2"},
+    {WindowID:3, Mark:"mark-3"},
+    {WindowID:444, Mark:"mark-4"},
+    {WindowID:5555, Mark:"mark-5"},
 }
 result:
 

--- a/cmd/focus.go
+++ b/cmd/focus.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/cristianoliveira/aerospace-marks/internal/aerospace"
@@ -45,29 +44,23 @@ Moves focus to the first window marked with the specified identifier.
 				return
 			}
 
-			if windowID == "" {
+			if windowID == 0 {
 				stdout.ErrorAndExitf("empty window id for mark '%s'", mark)
 				return
 			}
 			logger.LogDebug("Window found", "windowID", windowID)
 
-			intWindowID, err := strconv.Atoi(windowID)
-			if err != nil {
-				stdout.ErrorAndExitf("invalid window ID '%s'", windowID)
-				return
-			}
-
 			// The program is too fast, what a problem to have!
 			// Delay setting focus to ensure the window is ready
 			time.Sleep(focusDelay)
-			err = aerospaceClient.Client().SetFocusByWindowID(intWindowID)
+			err = aerospaceClient.Client().SetFocusByWindowID(windowID)
 			if err != nil {
 				stdout.ErrorAndExit(err)
 				return
 			}
 
 			logger.LogDebug("Focus set", "windowID", windowID)
-			fmt.Printf("Focus moved to window ID %s\n", windowID)
+			fmt.Printf("Focus moved to window ID %d\n", windowID)
 		},
 	}
 }

--- a/cmd/focus_test.go
+++ b/cmd/focus_test.go
@@ -45,7 +45,7 @@ func TestFocusCmd(t *testing.T) {
 		_, strg := mocks.MockStorageDbClient(ctrl)
 		strg.EXPECT().
 			GetWindowIDByMark("mark1").
-			Return("1", nil).
+			Return(1, nil).
 			Times(1)
 
 		mockAeroSpaceConnection, aerospaceClient := mocks.MockAerospaceConnection(ctrl)
@@ -80,7 +80,7 @@ func TestFocusCmd(t *testing.T) {
 
 		strg.EXPECT().
 			GetWindowIDByMark("nonexistent-mark").
-			Return("", nil).
+			Return(0, nil).
 			Times(1)
 
 		_, aerospaceClient := mocks.MockAerospaceConnection(ctrl)

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -44,7 +44,7 @@ This command retrieves a window by its mark (identifier). Print in the following
 			}
 
 			windowID := markedWindow.WindowID
-			if windowID == "" {
+			if windowID == 0 {
 				stdout.ErrorAndExit(fmt.Errorf("no window found for mark %s", mark))
 				return
 			}
@@ -68,7 +68,7 @@ This command retrieves a window by its mark (identifier). Print in the following
 				return
 			}
 			if window == nil {
-				stdout.ErrorAndExit(fmt.Errorf("no window found for ID %s", windowID))
+				stdout.ErrorAndExit(fmt.Errorf("no window found for ID %d", windowID))
 				return
 			}
 

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -24,7 +24,7 @@ func TestGetCommand(t *testing.T) {
 		_, strg := mocks.MockStorageDbClient(ctrl)
 		marks := []queries.Mark{
 			{
-				WindowID: "1",
+				WindowID: 1,
 				Mark:     "mark1",
 			},
 		}
@@ -93,7 +93,7 @@ func TestGetCommand(t *testing.T) {
 		_, strg := mocks.MockStorageDbClient(ctrl)
 		marks := []queries.Mark{
 			{
-				WindowID: "1",
+				WindowID: 1,
 				Mark:     "mark1",
 			},
 		}
@@ -142,7 +142,7 @@ func TestGetCommand(t *testing.T) {
 		_, strg := mocks.MockStorageDbClient(ctrl)
 		marks := []queries.Mark{
 			{
-				WindowID: "1",
+				WindowID: 1,
 				Mark:     "mark1",
 			},
 		}
@@ -211,7 +211,7 @@ func TestGetCommand(t *testing.T) {
 		_, strg := mocks.MockStorageDbClient(ctrl)
 		marks := []queries.Mark{
 			{
-				WindowID: "1",
+				WindowID: 1,
 				Mark:     "mark1",
 			},
 		}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -5,8 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
 	aerospacecli "github.com/cristianoliveira/aerospace-ipc"
 	"github.com/cristianoliveira/aerospace-marks/internal/aerospace"
@@ -17,14 +15,12 @@ import (
 	"slices"
 )
 
-func popWindow(windows []aerospacecli.Window, windowID string) (*aerospacecli.Window, error) {
+func popWindow(windows []aerospacecli.Window, windowID int) (*aerospacecli.Window, error) {
 	for i, window := range windows {
-		if windowID == "" {
+		if windowID == 0 {
 			return nil, fmt.Errorf("window ID not found")
 		}
-		winId := strconv.Itoa(window.WindowID)
-		winId = strings.TrimSpace(winId)
-		if windowID == winId {
+		if windowID == window.WindowID {
 			// Remove the window from the list
 			//nolint:staticcheck,ineffassign
 			windows = slices.Delete(windows, i, i+1)

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -26,11 +26,11 @@ func TestListCommand(t *testing.T) {
 			Return(
 				[]queries.Mark{
 					{
-						WindowID: "1",
+						WindowID: 1,
 						Mark:     "mark1",
 					},
 					{
-						WindowID: "2",
+						WindowID: 2,
 						Mark:     "mark2",
 					},
 				}, nil,
@@ -101,11 +101,11 @@ func TestListCommand(t *testing.T) {
 			Return(
 				[]queries.Mark{
 					{
-						WindowID: "1",
+						WindowID: 1,
 						Mark:     "mark1",
 					},
 					{
-						WindowID: "2",
+						WindowID: 2,
 						Mark:     "mark2",
 					},
 				}, nil,

--- a/cmd/mark.go
+++ b/cmd/mark.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/cristianoliveira/aerospace-marks/internal/aerospace"
@@ -54,21 +55,26 @@ aerospace-marks mark --add sec # Will add the mark sec to the current window [fi
 			silent, _ := cmd.Flags().GetBool("silent")
 
 			// Get the window ID from the command line argument
-			windowID := strings.TrimSpace(winArgID)
+			var windowID int
 			if winArgID == "" {
 				window, err := aerospaceClient.Client().GetFocusedWindow()
 				if err != nil {
 					stdout.ErrorAndExit(err)
 					return
 				}
-				windowID = fmt.Sprintf("%d", window.WindowID)
+				windowID = window.WindowID
 			} else {
-				window, err := aerospaceClient.GetWindowByID(windowID)
+				intWindowID, err := strconv.Atoi(strings.TrimSpace(winArgID))
+				if err != nil {
+					stdout.ErrorAndExitf("invalid window ID '%s'", winArgID)
+					return
+				}
+				window, err := aerospaceClient.GetWindowByID(intWindowID)
 				if err != nil {
 					stdout.ErrorAndExit(err)
 					return
 				}
-				windowID = fmt.Sprintf("%d", window.WindowID)
+				windowID = window.WindowID
 			}
 
 			// Manage marks using MarkClient

--- a/cmd/mark_test.go
+++ b/cmd/mark_test.go
@@ -24,7 +24,7 @@ func TestMarkCommand(t *testing.T) {
 
 		_, strg := mocks.MockStorageDbClient(ctrl)
 		strg.EXPECT().
-			ReplaceAllMarks("1", "mark1").
+			ReplaceAllMarks(1, "mark1").
 			Return(int64(1), nil).
 			Times(1)
 
@@ -76,7 +76,7 @@ func TestMarkCommand(t *testing.T) {
 
 		_, strg := mocks.MockStorageDbClient(ctrl)
 		strg.EXPECT().
-			ReplaceAllMarks("2", "mark1").
+			ReplaceAllMarks(2, "mark1").
 			Return(int64(1), nil).
 			Times(1)
 
@@ -133,7 +133,7 @@ func TestMarkCommand(t *testing.T) {
 
 		_, strg := mocks.MockStorageDbClient(ctrl)
 		strg.EXPECT().
-			AddMark("1", "mark2").
+			AddMark(1, "mark2").
 			Return(nil).
 			Times(1)
 
@@ -210,7 +210,7 @@ func TestMarkCommand(t *testing.T) {
 
 		_, strg := mocks.MockStorageDbClient(ctrl)
 		strg.EXPECT().
-			ToggleMark("2", "foobar").
+			ToggleMark(2, "foobar").
 			Return(nil).
 			Times(1)
 
@@ -262,7 +262,7 @@ func TestMarkCommand(t *testing.T) {
 
 		_, strg := mocks.MockStorageDbClient(ctrl)
 		strg.EXPECT().
-			ToggleMark("2", "foobar").
+			ToggleMark(2, "foobar").
 			Return(nil).
 			Times(1)
 

--- a/cmd/summon.go
+++ b/cmd/summon.go
@@ -4,8 +4,6 @@ Copyright © 2025 Cristian Oliveira license@cristianoliveira.dev
 package cmd
 
 import (
-	"strconv"
-
 	"github.com/cristianoliveira/aerospace-marks/internal/aerospace"
 	"github.com/cristianoliveira/aerospace-marks/internal/cli"
 	"github.com/cristianoliveira/aerospace-marks/internal/stdout"
@@ -44,7 +42,7 @@ Similar to 'aerospace summon-workspace' but for marked windows to current worksp
 				stdout.ErrorAndExit(err)
 				return
 			}
-			if windowID == "" {
+			if windowID == 0 {
 				stdout.ErrorAndExitf("no window found for mark '%s'", mark)
 				return
 			}
@@ -55,22 +53,15 @@ Similar to 'aerospace summon-workspace' but for marked windows to current worksp
 				return
 			}
 
-			// FIXME: windowsID as number
-			intWindowID, err := strconv.Atoi(windowID)
-			if err != nil {
-				stdout.ErrorAndExitf("invalid window ID '%s'", windowID)
-				return
-			}
-
 			// focus to window by ID
-			err = aerospaceClient.Client().MoveWindowToWorkspace(intWindowID, workspace.Workspace)
+			err = aerospaceClient.Client().MoveWindowToWorkspace(windowID, workspace.Workspace)
 			if err != nil {
 				stdout.ErrorAndExit(err)
 				return
 			}
 
 			if shouldFocus {
-				err := aerospaceClient.Client().SetFocusByWindowID(intWindowID)
+				err := aerospaceClient.Client().SetFocusByWindowID(windowID)
 				if err != nil {
 					stdout.ErrorAndExit(err)
 					return

--- a/internal/aerospace/windows.go
+++ b/internal/aerospace/windows.go
@@ -3,7 +3,6 @@ package aerospace
 import (
 	"fmt"
 	"log"
-	"strconv"
 
 	aerospacecli "github.com/cristianoliveira/aerospace-ipc"
 	"github.com/cristianoliveira/aerospace-marks/internal/logger"
@@ -14,7 +13,7 @@ type AerosSpaceMarkWindows interface {
 	//
 	// Returns the window ID of the currently focused window
 	// or an error if the window ID is not found
-	GetWindowByID(windowID string) (*aerospacecli.Window, error)
+	GetWindowByID(windowID int) (*aerospacecli.Window, error)
 
 	// Client returns the AeroSpaceWM client
 	//
@@ -35,7 +34,7 @@ func (d *DefaultAeroSpaceWindows) Client() *aerospacecli.AeroSpaceWM {
 	return d.client
 }
 
-func (d *DefaultAeroSpaceWindows) GetWindowByID(windowID string) (*aerospacecli.Window, error) {
+func (d *DefaultAeroSpaceWindows) GetWindowByID(windowID int) (*aerospacecli.Window, error) {
 	logger := logger.GetDefaultLogger()
 	windows, err := d.client.GetAllWindows()
 	if err != nil {
@@ -43,18 +42,13 @@ func (d *DefaultAeroSpaceWindows) GetWindowByID(windowID string) (*aerospacecli.
 	}
 	logger.LogDebug("Windows found: %d", len(windows))
 
-	intWindowID, err := strconv.Atoi(windowID)
-	if err != nil {
-		return nil, fmt.Errorf("invalid window ID '%s': %w", windowID, err)
-	}
-
 	for _, window := range windows {
-		if window.WindowID == intWindowID {
+		if window.WindowID == windowID {
 			return &window, nil
 		}
 	}
 
-	return nil, fmt.Errorf("window with ID %s not found", windowID)
+	return nil, fmt.Errorf("window with ID %d not found", windowID)
 }
 
 func NewAeroSpaceClient() (*DefaultAeroSpaceWindows, error) {

--- a/internal/mocks/fixtures/storage/list-marked-windows.json
+++ b/internal/mocks/fixtures/storage/list-marked-windows.json
@@ -1,22 +1,22 @@
 [
   {
-    "window_id": "1",
+    "window_id": 1,
     "mark": "mark-1"
   },
   {
-    "window_id": "22",
+    "window_id": 22,
     "mark": "mark-2"
   },
   {
-    "window_id": "3",
+    "window_id": 3,
     "mark": "mark-3"
   },
   {
-    "window_id": "444",
+    "window_id": 444,
     "mark": "mark-4"
   },
   {
-    "window_id": "5555",
+    "window_id": 5555,
     "mark": "mark-5"
   }
 ]

--- a/internal/mocks/storage/marks_mock.go
+++ b/internal/mocks/storage/marks_mock.go
@@ -42,7 +42,7 @@ func (m *MockMarkStorage) EXPECT() *MockMarkStorageMockRecorder {
 }
 
 // AddMark mocks base method.
-func (m *MockMarkStorage) AddMark(id, mark string) error {
+func (m *MockMarkStorage) AddMark(id int, mark string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddMark", id, mark)
 	ret0, _ := ret[0].(error)
@@ -144,7 +144,7 @@ func (mr *MockMarkStorageMockRecorder) GetMarks() *gomock.Call {
 }
 
 // GetMarksByWindowID mocks base method.
-func (m *MockMarkStorage) GetMarksByWindowID(id string) ([]queries.Mark, error) {
+func (m *MockMarkStorage) GetMarksByWindowID(id int) ([]queries.Mark, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMarksByWindowID", id)
 	ret0, _ := ret[0].([]queries.Mark)
@@ -174,10 +174,10 @@ func (mr *MockMarkStorageMockRecorder) GetWindowByMark(mark any) *gomock.Call {
 }
 
 // GetWindowIDByMark mocks base method.
-func (m *MockMarkStorage) GetWindowIDByMark(mark string) (string, error) {
+func (m *MockMarkStorage) GetWindowIDByMark(mark string) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWindowIDByMark", mark)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -189,7 +189,7 @@ func (mr *MockMarkStorageMockRecorder) GetWindowIDByMark(mark any) *gomock.Call 
 }
 
 // ReplaceAllMarks mocks base method.
-func (m *MockMarkStorage) ReplaceAllMarks(id, mark string) (int64, error) {
+func (m *MockMarkStorage) ReplaceAllMarks(id int, mark string) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplaceAllMarks", id, mark)
 	ret0, _ := ret[0].(int64)
@@ -204,7 +204,7 @@ func (mr *MockMarkStorageMockRecorder) ReplaceAllMarks(id, mark any) *gomock.Cal
 }
 
 // ToggleMark mocks base method.
-func (m *MockMarkStorage) ToggleMark(id, mark string) error {
+func (m *MockMarkStorage) ToggleMark(id int, mark string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ToggleMark", id, mark)
 	ret0, _ := ret[0].(error)

--- a/internal/storage/db/queries/marks.sql.go
+++ b/internal/storage/db/queries/marks.sql.go
@@ -14,7 +14,7 @@ const addMark = `-- name: AddMark :exec
 INSERT INTO marks (window_id, mark) VALUES (?, ?)
 `
 
-func (q *Queries) AddMark(ctx context.Context, windowID string, mark string) error {
+func (q *Queries) AddMark(ctx context.Context, windowID int, mark string) error {
 	_, err := q.db.ExecContext(ctx, addMark, windowID, mark)
 	return err
 }
@@ -39,7 +39,7 @@ const deleteByWindow = `-- name: DeleteByWindow :execresult
 DELETE FROM marks WHERE window_id = ?
 `
 
-func (q *Queries) DeleteByWindow(ctx context.Context, windowID string) (sql.Result, error) {
+func (q *Queries) DeleteByWindow(ctx context.Context, windowID int) (sql.Result, error) {
 	return q.db.ExecContext(ctx, deleteByWindow, windowID)
 }
 
@@ -47,7 +47,7 @@ const deleteMarksByWindowIDOrMark = `-- name: DeleteMarksByWindowIDOrMark :execr
 DELETE FROM marks WHERE window_id = ? OR mark = ?
 `
 
-func (q *Queries) DeleteMarksByWindowIDOrMark(ctx context.Context, windowID string, mark string) (sql.Result, error) {
+func (q *Queries) DeleteMarksByWindowIDOrMark(ctx context.Context, windowID int, mark string) (sql.Result, error) {
 	return q.db.ExecContext(ctx, deleteMarksByWindowIDOrMark, windowID, mark)
 }
 
@@ -84,7 +84,7 @@ FROM marks
 WHERE window_id = ?
 `
 
-func (q *Queries) GetMarksByWindowID(ctx context.Context, windowID string) ([]Mark, error) {
+func (q *Queries) GetMarksByWindowID(ctx context.Context, windowID int) ([]Mark, error) {
 	rows, err := q.db.QueryContext(ctx, getMarksByWindowID, windowID)
 	if err != nil {
 		return nil, err

--- a/internal/storage/db/queries/models.go
+++ b/internal/storage/db/queries/models.go
@@ -7,6 +7,6 @@ package queries
 // Mark represents a mark in the database
 // This is an alias to the Mark struct in the parent storage package
 type Mark = struct {
-	WindowID string `json:"window_id"`
+	WindowID int    `json:"window_id"`
 	Mark     string `json:"mark"`
 }

--- a/internal/storage/marks.go
+++ b/internal/storage/marks.go
@@ -11,19 +11,19 @@ import (
 
 type MarkStorage interface {
 	// AddMark adds a mark to the database
-	AddMark(id string, mark string) error
+	AddMark(id int, mark string) error
 	// GetMarks returns all marks in the database
 	GetMarks() ([]queries.Mark, error)
 	// GetMarksByWindowID returns all marks for a given window ID
-	GetMarksByWindowID(id string) ([]queries.Mark, error)
+	GetMarksByWindowID(id int) ([]queries.Mark, error)
 	// GetWindowByMark returns the window for a given mark
 	GetWindowByMark(mark string) (*queries.Mark, error)
 	// GetWindowIDByMark returns the window ID for a given mark
-	GetWindowIDByMark(mark string) (string, error)
+	GetWindowIDByMark(mark string) (int, error)
 	// ReplaceAllMarks replaces all marks for a window with a new mark
-	ReplaceAllMarks(id string, mark string) (int64, error)
+	ReplaceAllMarks(id int, mark string) (int64, error)
 	// ToggleMark toggles a mark for a window
-	ToggleMark(id string, mark string) error
+	ToggleMark(id int, mark string) error
 	// DeleteByMark removes a mark from the database
 	DeleteByMark(mark string) (int64, error)
 	// DeleteByMark removes a mark from the database
@@ -54,7 +54,7 @@ func NewMarkClient(storageClient StorageDbClient) (*MarkStorageClient, error) {
 	return client, nil
 }
 
-func (c *MarkStorageClient) AddMark(id string, mark string) error {
+func (c *MarkStorageClient) AddMark(id int, mark string) error {
 	ctx := context.Background()
 	return c.queries.AddMark(ctx, id, mark)
 }
@@ -64,7 +64,7 @@ func (c *MarkStorageClient) GetMarks() ([]queries.Mark, error) {
 	return c.queries.GetAllMarks(ctx)
 }
 
-func (c *MarkStorageClient) GetMarksByWindowID(id string) ([]queries.Mark, error) {
+func (c *MarkStorageClient) GetMarksByWindowID(id int) ([]queries.Mark, error) {
 	ctx := context.Background()
 	return c.queries.GetMarksByWindowID(ctx, id)
 }
@@ -90,14 +90,14 @@ func (c *MarkStorageClient) GetWindowByMark(mark string) (*queries.Mark, error) 
 //
 // This function will return the first window ID that matches the mark
 // If multiple window IDs match the mark, it will return the first one found
-func (c *MarkStorageClient) GetWindowIDByMark(markI string) (string, error) {
+func (c *MarkStorageClient) GetWindowIDByMark(markI string) (int, error) {
 	ctx := context.Background()
 	markedWindow, err := c.queries.GetWindowByMark(ctx, markI)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return "", fmt.Errorf("no window found for mark %s", markI)
+			return 0, fmt.Errorf("no window found for mark %s", markI)
 		}
-		return "", err
+		return 0, err
 	}
 
 	return markedWindow.WindowID, nil
@@ -106,7 +106,7 @@ func (c *MarkStorageClient) GetWindowIDByMark(markI string) (string, error) {
 // ReplaceAllMarks replaces all marks for a window with a new mark
 // This function will delete all marks for the specified window ID and
 // then add the new mark
-func (c *MarkStorageClient) ReplaceAllMarks(id string, mark string) (int64, error) {
+func (c *MarkStorageClient) ReplaceAllMarks(id int, mark string) (int64, error) {
 	ctx := context.Background()
 
 	// Delete all marks for the window
@@ -139,7 +139,7 @@ func (c *MarkStorageClient) Client() StorageDbClient {
 // ToggleMark toggles a mark for a window
 // If the mark exists, it will be deleted
 // If the mark does not exist, it will be added
-func (c *MarkStorageClient) ToggleMark(id string, mark string) error {
+func (c *MarkStorageClient) ToggleMark(id int, mark string) error {
 	rowsAffected, err := c.DeleteByMark(mark)
 	if err != nil {
 		return err
@@ -195,9 +195,7 @@ func (c *MarkStorageClient) DeleteByMark(mark string) (int64, error) {
 // This function will delete the mark from the database
 func (c *MarkStorageClient) DeleteByWindow(windowId int) (int64, error) {
 	ctx := context.Background()
-	// Convert int to string since our SQLC queries expect string
-	windowIdStr := fmt.Sprintf("%d", windowId)
-	res, err := c.queries.DeleteByWindow(ctx, windowIdStr)
+	res, err := c.queries.DeleteByWindow(ctx, windowId)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/testutils/clis.go
+++ b/internal/testutils/clis.go
@@ -106,7 +106,7 @@ func (d *MockEmptyAerspaceMarkWindows) Client() *aerospacecli.AeroSpaceWM {
 	return &aerospacecli.AeroSpaceWM{}
 }
 
-func (d *MockEmptyAerspaceMarkWindows) GetWindowByID(windowID string) (*aerospacecli.Window, error) {
+func (d *MockEmptyAerspaceMarkWindows) GetWindowByID(windowID int) (*aerospacecli.Window, error) {
 	fmt.Println("Mocked GetWindowByID called with windowID:", windowID)
 	return &aerospacecli.Window{}, nil
 }


### PR DESCRIPTION
Summary:
This commit refactors the codebase to change the `WindowID` from string to integer type to ensure consistency accross