### PR TITLE
fix: list command shows consistent amount of cols

### DIFF
--- a/cmd/__snapshots__/list_test.snap
+++ b/cmd/__snapshots__/list_test.snap
@@ -47,8 +47,8 @@
 }
 result:
 
-mark-1 | 1 | Alacritty     | Alacritty     
-mark-3 | 3 | Brave Browser | GitHub - Brave
+mark-1 | 1 | Alacritty     | Alacritty      | _ | _
+mark-3 | 3 | Brave Browser | GitHub - Brave | _ | _
 ---
 
 [TestListCommand/print_all_marked_windows#01 - 1]
@@ -59,7 +59,7 @@ List all marked windows
 This command lists all marked windows with their respective marks.
 Display in the following format:
 
-<mark>|<window-id>|<window-title>|<window-app>
+<mark>|<window-id>|<app-name>|<window-title>|<workspace>|<app-bundle-id>
 
 Usage:
   aerospace-marks list [flags]

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -45,7 +45,7 @@ func ListCmd(
 This command lists all marked windows with their respective marks.
 Display in the following format:
 
-<mark>|<window-id>|<window-title>|<window-app>
+<mark>|<window-id>|<app-name>|<window-title>|<workspace>|<app-bundle-id>
 	`,
 		Run: func(cmd *cobra.Command, args []string) {
 			marks, err := storageClient.GetMarks()
@@ -71,7 +71,27 @@ Display in the following format:
 					continue
 				}
 
-				line := fmt.Sprintf("%s|%s\r\n", mark.Mark, window)
+				// Format window fields, using "_" for empty fields
+				windowID := fmt.Sprintf("%d", window.WindowID)
+				appName := window.AppName
+				if appName == "" {
+					appName = "_"
+				}
+				windowTitle := window.WindowTitle
+				if windowTitle == "" {
+					windowTitle = "_"
+				}
+				workspace := window.Workspace
+				if workspace == "" {
+					workspace = "_"
+				}
+				appBundleID := window.AppBundleID
+				if appBundleID == "" {
+					appBundleID = "_"
+				}
+
+				line := fmt.Sprintf("%s|%s|%s|%s|%s|%s\r\n",
+					mark.Mark, windowID, appName, windowTitle, workspace, appBundleID)
 				lines = append(lines, line)
 			}
 

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -42,16 +42,22 @@ func TestListCommand(t *testing.T) {
 				WindowID:    1,
 				WindowTitle: "title1",
 				AppName:     "app1",
+				Workspace:   "",
+				AppBundleID: "",
 			},
 			{
 				WindowID:    2,
 				WindowTitle: "title2",
 				AppName:     "app2",
+				Workspace:   "",
+				AppBundleID: "",
 			},
 			{
 				WindowID:    3,
 				WindowTitle: "title3",
 				AppName:     "app3",
+				Workspace:   "",
+				AppBundleID: "",
 			},
 		}
 		jsonData, err := json.Marshal(windows)
@@ -86,8 +92,8 @@ func TestListCommand(t *testing.T) {
 		lines := strings.Split(result, "\n")
 		assert.Equal(t, 2, len(lines))
 		assert.Equal(t, lines, []string{
-			"mark1 | 1 | app1 | title1",
-			"mark2 | 2 | app2 | title2",
+			"mark1 | 1 | app1 | title1 | _ | _",
+			"mark2 | 2 | app2 | title2 | _ | _",
 		})
 	})
 
@@ -117,16 +123,22 @@ func TestListCommand(t *testing.T) {
 				WindowID:    111,
 				WindowTitle: "title1",
 				AppName:     "app1",
+				Workspace:   "",
+				AppBundleID: "",
 			},
 			{
 				WindowID:    222,
 				WindowTitle: "title2",
 				AppName:     "app2",
+				Workspace:   "",
+				AppBundleID: "",
 			},
 			{
 				WindowID:    333,
 				WindowTitle: "title3",
 				AppName:     "app3",
+				Workspace:   "",
+				AppBundleID: "",
 			},
 		}
 		jsonData, err := json.Marshal(windows)

--- a/internal/format/list_test.go
+++ b/internal/format/list_test.go
@@ -23,3 +23,18 @@ func TestTableOutFormatSameLength(t *testing.T) {
 	assert.Equal(t, lines[2], "3   | another         | title3")
 	assert.Equal(t, lines[3], "212 | app4            | title4")
 }
+
+func TestTableOutFormatWithSixColumns(t *testing.T) {
+	list := []string{
+		"mark1|1|app1|title1|workspace1|bundle1\r\n",
+		"mark2|2|app2 super long|title2|_|bundle2\r\n",
+		"mark3|3|app3|_|workspace3|_\r\n",
+	}
+	result := FormatTableList(list)
+	lines := strings.Split(result, "\n")
+
+	assert.Equal(t, 3, len(lines))
+	assert.Equal(t, lines[0], "mark1 | 1 | app1            | title1 | workspace1 | bundle1")
+	assert.Equal(t, lines[1], "mark2 | 2 | app2 super long | title2 | _          | bundle2")
+	assert.Equal(t, lines[2], "mark3 | 3 | app3            | _      | workspace3 | _      ")
+}


### PR DESCRIPTION
Summary:
This commit modifies the `list` command to display columns consitently.

Detailed Changes:
 - cmd/list.go:
   - Altered the list command format to add `app-name`, `workspace`, and `app-bundle-id` fields, using "_" for empty fields.
 - cmd/list_test.go:
   - Adjusted test cases to validate the new format with additional fields and placeholders for missing values.