### PR TITLE
Upgrade to go 1.26 to fix nix build error

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748639162,
-        "narHash": "sha256-sgO8YwYC+01Pjr/HgdOmIGmxVRmFgXHaH29jO5xtJI0=",
+        "lastModified": 1774502759,
+        "narHash": "sha256-2UE1o2sjpuit4XDNO9lE7k83Uy0Lqxgo0xCElLz8R6k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6a43740d5694345c3e8464e4a52e61c96f109803",
+        "rev": "50e6e147d704e1f510c85093b548fd8d7301f7f7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
       in {
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [
-            go_1_24
+            go_1_26
 
             golangci-lint
 

--- a/nix/package-default.nix
+++ b/nix/package-default.nix
@@ -3,7 +3,7 @@
     name = "aerospace-marks";
     version = "v1.0.0";
 
-    go = pkgs.go_1_24;
+    go = pkgs.go_1_26;
 
     # sources that will be used for our derivation.
     src = pkgs.fetchFromGitHub {

--- a/nix/package-nightly.nix
+++ b/nix/package-nightly.nix
@@ -4,7 +4,7 @@
     name = "aerospace-marks";
     version = "nightly"; # Branch 
 
-    go = pkgs.go_1_24;
+    go = pkgs.go_1_26;
 
     # sources that will be used for our derivation.
     src = pkgs.fetchFromGitHub {

--- a/nix/package-source.nix
+++ b/nix/package-source.nix
@@ -1,10 +1,10 @@
 { pkgs, ... }:
-  pkgs.buildGo124Module rec {
+  pkgs.buildGoModule rec {
     # name of our derivation
     name = "aerospace-marks";
     version = "source";
 
-    go = pkgs.go_1_24;
+    go = pkgs.go_1_26;
 
     # sources that will be used for our derivation.
     src = ../.;


### PR DESCRIPTION
Recently, nixpkgs removed go 1.24 (https://github.com/NixOS/nixpkgs/commit/88452f2e1f75f2c3bfb2af1768ca1c771093d1af). This PR upgrades go 1.24 to 1.26.