### PR TITLE
chore: upgrade Go to 1.26.0 and optimize string formatting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,17 @@
 module github.com/cristianoliveira/aerospace-marks
 
-go 1.24.2
-
-toolchain go1.24.3
+go 1.26.0
 
 require (
 	github.com/cristianoliveira/aerospace-ipc v0.3.0
 	github.com/gkampitakis/go-snaps v0.5.11
+	github.com/kr/pretty v0.3.1
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/pressly/goose/v3 v3.24.3
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/mock v0.5.2
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -20,7 +20,6 @@ require (
 	github.com/gkampitakis/go-diff v1.3.2 // indirect
 	github.com/goccy/go-yaml v1.15.13 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/maruel/natural v1.1.1 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
@@ -34,7 +33,6 @@ require (
 	github.com/tidwall/sjson v1.2.5 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/sync v0.14.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 // NOTE: for development only

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cristianoliveira/aerospace-ipc v0.2.2-0.20251130105333-9de15e5631ea h1:TxSgDKNuYIEbIzV+hLD7qzzO5W+BUU+CCHP+jltI7yM=
-github.com/cristianoliveira/aerospace-ipc v0.2.2-0.20251130105333-9de15e5631ea/go.mod h1:Dr928g0F980Y/Hu1t60RKOiWvQF02Lx5nLLM0SwPZ7M=
-github.com/cristianoliveira/aerospace-ipc v0.2.2-0.20251130115621-503d03b8be64 h1:pOOBFRnKrWwDr2n2eJ7eQv8X5ouWePdrD8b1CaF41N4=
-github.com/cristianoliveira/aerospace-ipc v0.2.2-0.20251130115621-503d03b8be64/go.mod h1:Dr928g0F980Y/Hu1t60RKOiWvQF02Lx5nLLM0SwPZ7M=
 github.com/cristianoliveira/aerospace-ipc v0.3.0 h1:7OyDwzQaA8yO9HHdVG0//t0ExSx4Jit7uRJywf3hAn4=
 github.com/cristianoliveira/aerospace-ipc v0.3.0/go.mod h1:Dr928g0F980Y/Hu1t60RKOiWvQF02Lx5nLLM0SwPZ7M=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/format/list.go
+++ b/internal/format/list.go
@@ -44,7 +44,7 @@ func FormatTableList(list []string) string {
 	var b strings.Builder
 	for i, row := range rows {
 		for j, field := range row {
-			b.WriteString(fmt.Sprintf("%-*s", colWidths[j], field))
+			fmt.Fprintf(&b, "%-*s", colWidths[j], field)
 			if j < len(row)-1 {
 				b.WriteString(" | ")
 			}

--- a/internal/format/output.go
+++ b/internal/format/output.go
@@ -127,7 +127,7 @@ func (f *ListOutputFormatter) formatText(windows []MarkedWindow) error {
 	var b strings.Builder
 	for i, row := range rows {
 		for j, field := range row {
-			b.WriteString(fmt.Sprintf("%-*s", colWidths[j], field))
+			fmt.Fprintf(&b, "%-*s", colWidths[j], field)
 			if j < len(row)-1 {
 				b.WriteString(" | ")
 			}


### PR DESCRIPTION
## Summary
Upgrades the project from Go 1.24.2 to Go 1.26.0 with related improvements.

## Changes
- **Go version**: Updated from 1.24.2 to 1.26.0 in go.mod
- **Toolchain**: Removed explicit toolchain directive (Go 1.26+ auto-manages toolchain)
- **Performance optimization**: Replaced `b.WriteString(fmt.Sprintf(...))` with `fmt.Fprintf(&b, ...)` for better string formatting performance
- **Tooling**: Upgraded golangci-lint to v2 (required for Go 1.26 compatibility)

## Validation
- ✅ All tests pass (`make test`)
- ✅ No formatting issues (`make fmt`)
- ✅ No linting errors (`make lint`)
- ✅ Nix build successful (`nix build .#default`)

## Breaking Changes
None - this is a tooling upgrade only.