### PR TITLE
fix(ci): build macOS release binaries natively to enable CGO

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix:
         goos: [darwin]
@@ -27,11 +27,13 @@ jobs:
         if: github.event_name == 'release'
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24'  # Specify your Go version
+          go-version: '1.26'
 
       - name: Build and Release
         if: github.event_name == 'release'
         uses: wangyoucao577/go-release-action@v1
+        env:
+          CGO_ENABLED: 1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}


### PR DESCRIPTION
Fixes [#68](https://github.com/cristianoliveira/aerospace-marks/issues/68) — Homebrew builds produce stub binaries because CGO is disabled during cross-compilation.

## Problem
The release workflow ran on `ubuntu-latest`, cross-compiling for `darwin`. Go cross-compilation Linux→macOS forces `CGO_ENABLED=0`, producing a stub `go-sqlite3` binary that panics at runtime.

## Fix
- **Runner:** `ubuntu-latest` → `macos-latest` — native macOS build, CGO enabled by default
- **CGO flag:** Explicit `CGO_ENABLED: 1` in the build step
- **Go version:** `1.24` → `1.26` to match `go.mod`

macOS runners support both `amd64` and `arm64` compilation natively via Apple's toolchain.

## After merge
Create a new release to trigger rebuilt binaries. Then update the Homebrew formula with the new SHA256 hashes.