### PR TITLE
docs: update AeroSpace compatibility for aerospace-ipc v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,14 @@
 
 ## AeroSpace Compatibility
 
+AeroSpace introduced a new socket protocol (handshake + framing) in 0.21.0.
+aerospace-marks tracks the latest protocol, so older AeroSpace versions must
+pin an older release:
+
  - Stable version: v1.0.0
- - v0.20.0 use v0.3.x or higher
- - v0.19.1 use v0.2.x or lower
+ - AeroSpace 0.21.x → use aerospace-marks latest
+ - AeroSpace 0.20.x → pin aerospace-marks to v1.0.2
+ - AeroSpace 0.19.x → use aerospace-marks v0.2.x or lower
 
 ## Demo
 


### PR DESCRIPTION
## Summary

Follow-up to **#71** (aerospace-ipc v0.4.0 bump). The bump was merged without its docs change, so `main` currently ships code that **requires AeroSpace 0.21.x** while the README still tells `0.20.0` users to use the latest release.

### Why this matters

aerospace-ipc v0.4.0 adopts the new AeroSpace socket protocol (handshake + framing, added in AeroSpace 0.21.0). At runtime, `CheckServerVersion` enforces an **exact `0.21.x` match** (major=0, minor=21). This is a change from v0.3.0, which required `0.20.x`.

So the previous line `v0.20.0 use v0.3.x or higher` is now wrong — the new release rejects AeroSpace 0.20.x.

## Changes

Updates the **AeroSpace Compatibility** section in `README.md`:

```diff
-AeroSpace Compatibility
- - Stable version: v1.0.0
- - v0.20.0 use v0.3.x or higher
- - v0.19.1 use v0.2.x or lower
+AeroSpace introduced a new socket protocol (handshake + framing) in 0.21.0.
+aerospace-marks tracks the latest protocol, so older AeroSpace versions must
+pin an older release:
+
+ - Stable version: v1.0.0
+ - AeroSpace 0.21.x → use aerospace-marks latest
+ - AeroSpace 0.20.x → pin aerospace-marks to v1.0.2
+ - AeroSpace 0.19.x → use aerospace-marks v0.2.x or lower
```

Docs-only change, no code impact.